### PR TITLE
fix: 상세 페이지에서 뒤로가기 클릭 시 홈 화면으로 이동하는 버그 해결

### DIFF
--- a/src/components/navigation/CustomHeader.tsx
+++ b/src/components/navigation/CustomHeader.tsx
@@ -1,6 +1,5 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Pressable, Text, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 import type { HeaderProps } from '@/types/Header';
 import Icon from '@common/Icon';
 import SaveButton from '@common/SaveButton';
@@ -14,17 +13,17 @@ const CustomHeader = ({
   iconColor = 'white',
   hasButton,
   title,
+  onBack,
   onPress,
   isLoading,
   disabled,
 }: HeaderProps) => {
-  const navigation = useNavigation();
   return (
     <SafeAreaView edges={['top']} style={{ backgroundColor: bgColor }}>
       <View className="h-[60px] flex-row items-center justify-between px-7 py-4">
         <View className="flex-row gap-5">
           {hasBack && (
-            <Pressable onPress={() => navigation.goBack()}>
+            <Pressable onPress={onBack}>
               <Icon name="IcBack" size={28} color={'white'} />
             </Pressable>
           )}

--- a/src/navigation/letter/LetterStackNavigator.tsx
+++ b/src/navigation/letter/LetterStackNavigator.tsx
@@ -14,8 +14,8 @@ const LetterStackNavigator = () => {
       initialRouteName="LetterScreen"
       screenOptions={{
         header: (props) => {
-          const { navigation, options, back } = props;
-          const { hasBack, hasLogo, hasButton, icon, iconSize, iconColor, title, onPress } =
+          const { options, back } = props;
+          const { hasBack, hasLogo, hasButton, icon, iconSize, iconColor, title, onPress, onBack } =
             options as unknown as HeaderProps;
           return (
             <CustomHeader
@@ -26,10 +26,7 @@ const LetterStackNavigator = () => {
               iconSize={iconSize}
               iconColor={iconColor}
               title={title}
-              onBack={() => {
-                if (navigation.canGoBack()) navigation.goBack();
-                navigation.getParent()?.navigate('Tabs', { screen: 'Home' });
-              }}
+              onBack={onBack}
               onPress={onPress}
             />
           );

--- a/src/screens/letter/LetterDetailScreen.tsx
+++ b/src/screens/letter/LetterDetailScreen.tsx
@@ -154,6 +154,7 @@ const LetterDetailScreen: React.FC<Props> = ({ route, navigation }) => {
     setHeaderExtras(navigation, {
       title: '기억의 별자리',
       hasBack: true,
+      onBack: () => navigation.replace('LetterScreen'),
       ...(isOwner
         ? {
             hasButton: true,

--- a/src/screens/letter/LetterScreen.tsx
+++ b/src/screens/letter/LetterScreen.tsx
@@ -19,6 +19,10 @@ const LetterScreen = () => {
       icon: 'IcNotification',
       iconSize: 28,
       iconColor: 'white',
+      onBack: () => {
+        if (navigation.canGoBack()) navigation.goBack();
+        navigation.getParent()?.navigate('Tabs', { screen: 'Home' });
+      },
       onPress: () => rootNavigation.navigate('NotificationList'),
     });
   }, [navigation]);

--- a/src/screens/letter/LetterWriteScreen.tsx
+++ b/src/screens/letter/LetterWriteScreen.tsx
@@ -106,6 +106,7 @@ const LetterWriteScreen = () => {
       disabled: !letter.trim() || isSaving || hasSubmitted,
       hasBack: true,
       hasButton: true,
+      onBack: () => navigation.goBack(),
       onPress: handleSave,
     });
   }, [navigation, handleSave, letter, isSaving, hasSubmitted, editingId]);


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#42 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 알림 화면에서 기억의 별자리 상세 화면으로 이동 시 뒤로 가기 버튼 눌렀을 때 홈 화면으로 이동하는 문제 해결
- 상세 -> 피드로 이동하도록 수정
- 커스텀 헤더에 onBack prop 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
